### PR TITLE
Include base.js in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-oniyi",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "An opinionated generator for node.js modules. Making use of Babel, AVA, NYC",
   "main": "index.js",
   "scripts": {
@@ -31,7 +31,8 @@
     "generators/src",
     "generators/test",
     "generators/readme",
-    "generators/setup"
+    "generators/setup",
+    "generators/base.js"
   ],
   "dependencies": {
     "defined": "^1.0.0",


### PR DESCRIPTION
`files` in `package.json` was missing `generators/base.js`, resulting in this error when trying to run `yo oniyi`:

```bash
module.js:442
    throw err;
    ^

Error: Cannot find module '../base'
    at Function.Module._resolveFilename (module.js:440:15)
    at Function.Module._load (module.js:388:25)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/ako/.nvm/versions/node/v6.2.2/lib/node_modules/generator-oniyi/generators/app/index.js:10:14)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)

```